### PR TITLE
Fixed: missing requirements gunicorn

### DIFF
--- a/flask_app/requirements.txt
+++ b/flask_app/requirements.txt
@@ -1,3 +1,4 @@
+gunicorn==20.0.4
 click==7.1.2
 Flask==1.1.2
 itsdangerous==1.1.0


### PR DESCRIPTION
ocker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "gunicorn": executable file not 
found in $PATH: unknown.